### PR TITLE
feat(ci): add auto-approve workflow for owner PRs

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -1,16 +1,14 @@
 name: Auto Approve
+
 on:
-  pull_request:
+  pull_request_target:
     types: [opened, synchronize, ready_for_review]
 
 jobs:
   approve:
     runs-on: ubuntu-latest
-    # Only run if the PR is not a draft AND the author is the repository owner
-    if: |
-      github.event.pull_request.draft == false && 
-      github.event.pull_request.user.login == github.repository_owner
-    
+    if: ${{ !github.event.pull_request.draft && github.event.pull_request.user.login == 'pixel-miner' }}
+
     permissions:
       pull-requests: write
 


### PR DESCRIPTION
## Changes
- Add `.github/workflows/main.yml` with `pull_request_target` trigger
- Gate approval on PR author matching `pixel-miner`
- Use `hmarr/auto-approve-action@v4` with `pull-requests: write` scope
- Fix condition to compare against the user account, not the org name

Closes #3