### PR TITLE
fix(deps): regenerate Cargo.lock with correct regex-syntax checksum

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -317,7 +317,7 @@ dependencies = [
 name = "regex-syntax"
 version = "0.8.10"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "dc897dd8d9e8bd1ed8cdad82b5986c3e0ecae09fb1907d58efaa013543185d0a"
+checksum = "dc897dd8d9e8bd1ed8cdad82b5966c3e0ecae09fb1907d58efaa013543185d0a"
 
 [[package]]
 name = "scopeguard"


### PR DESCRIPTION
## Changes
- Regenerate `Cargo.lock` to fix a stale checksum for `regex-syntax v0.8.10`
  that blocked `cargo build --release`

Closes #5