### PR TITLE
feat(ci): add cross-platform CI matrix and release artifact workflow

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,39 @@
+name: CI
+
+on:
+  push:
+    branches: [main]
+  pull_request:
+    branches: [main]
+
+jobs:
+  ci:
+    name: CI (${{ matrix.os }})
+    runs-on: ${{ matrix.os }}
+    strategy:
+      matrix:
+        os: [ubuntu-latest, macos-latest, windows-latest]
+      fail-fast: false
+
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Install Rust
+        uses: dtolnay/rust-toolchain@stable
+        with:
+          components: rustfmt, clippy
+
+      - name: Cache
+        uses: Swatinem/rust-cache@v2
+
+      - name: Install nextest
+        uses: taiki-e/install-action@nextest
+
+      - name: Format check
+        run: cargo fmt --check
+
+      - name: Clippy
+        run: cargo clippy -- -D warnings
+
+      - name: Tests
+        run: cargo nextest run

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,0 +1,37 @@
+name: Release
+
+on:
+  push:
+    tags:
+      - 'v*'
+
+jobs:
+  upload-assets:
+    name: Release (${{ matrix.target }})
+    runs-on: ${{ matrix.os }}
+    strategy:
+      matrix:
+        include:
+          - target: x86_64-unknown-linux-gnu
+            os: ubuntu-latest
+          - target: aarch64-unknown-linux-gnu
+            os: ubuntu-latest
+          - target: x86_64-apple-darwin
+            os: macos-latest
+          - target: aarch64-apple-darwin
+            os: macos-latest
+          - target: x86_64-pc-windows-msvc
+            os: windows-latest
+
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Install Rust
+        uses: dtolnay/rust-toolchain@stable
+
+      - name: Upload binary
+        uses: taiki-e/upload-rust-binary-action@v1
+        with:
+          bin: godot-lsp-bridge
+          target: ${{ matrix.target }}
+          token: ${{ secrets.GITHUB_TOKEN }}

--- a/README.md
+++ b/README.md
@@ -33,7 +33,7 @@ A high-performance Rust proxy that bridges Godot's TCP Language Server (port 600
   - Buffered reader that reconstructs complete JSON-RPC messages before forwarding
   - Unit tests covering fragmented / batched TCP payloads
 
-- [ ] **Phase 3 — Cross-platform CI/CD (GitHub Actions)**
+- [x] **Phase 3 — Cross-platform CI/CD (GitHub Actions)**
   - Matrix: `ubuntu-latest`, `macos-latest`, `windows-latest`
   - Gates: `cargo fmt --check`, `cargo clippy -- -D warnings`, `cargo nextest run`
   - Release artifacts: pre-built binaries uploaded per tag


### PR DESCRIPTION
## Changes
- Add `.github/workflows/ci.yml` with a matrix over `ubuntu-latest`, `macos-latest`, and `windows-latest`; runs `cargo fmt --check`, `cargo clippy -- -D warnings`, and `cargo nextest run` on every PR and push to `main`
- Add `.github/workflows/release.yml` triggered on `v*` tags; builds and uploads pre-built binaries for 5 targets (Linux x86_64, Linux aarch64, macOS x86_64, macOS aarch64, Windows x86_64) via `taiki-e/upload-rust-binary-action`
- Mark Phase 3 complete in README roadmap

Closes #11

## References
[1]: https://nexte.st/book/ci.html
[2]: https://github.com/taiki-e/upload-rust-binary-action