### PR TITLE
feat(shader): synthesise diagnostics for .gdshader files

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -407,6 +407,7 @@ dependencies = [
  "dirs",
  "flate2",
  "futures",
+ "percent-encoding",
  "reqwest",
  "serde",
  "serde_json",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -255,6 +255,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "fastrand"
+version = "2.4.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9f1f227452a390804cdb637b74a86990f2a7d7ba4b7d5693aac9b4dd6defd8d6"
+
+[[package]]
 name = "filetime"
 version = "0.2.27"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -405,6 +411,7 @@ dependencies = [
  "serde",
  "serde_json",
  "tar",
+ "tempfile",
  "tokio",
  "tokio-test",
  "tracing",
@@ -1306,6 +1313,19 @@ dependencies = [
  "filetime",
  "libc",
  "xattr",
+]
+
+[[package]]
+name = "tempfile"
+version = "3.27.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "32497e9a4c7b38532efcdebeef879707aa9f794296a4f0244f6f69e9bc8574bd"
+dependencies = [
+ "fastrand",
+ "getrandom 0.3.4",
+ "once_cell",
+ "rustix",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -400,7 +400,7 @@ dependencies = [
 
 [[package]]
 name = "godot-lsp-bridge"
-version = "1.2.0"
+version = "1.3.0"
 dependencies = [
  "anyhow",
  "clap",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -43,6 +43,9 @@ reqwest = { version = "0.12", default-features = false, features = ["json", "rus
 # Platform config/home directory resolution
 dirs = "5"
 
+# URI percent-decoding for file:// paths
+percent-encoding = "2"
+
 # Temporary files for shader validation script
 tempfile = "3"
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -43,6 +43,9 @@ reqwest = { version = "0.12", default-features = false, features = ["json", "rus
 # Platform config/home directory resolution
 dirs = "5"
 
+# Temporary files for shader validation script
+tempfile = "3"
+
 # Archive extraction for update subcommand
 flate2 = "1"
 tar    = "0.4"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name        = "godot-lsp-bridge"
-version     = "1.2.0"
+version     = "1.3.0"
 edition     = "2021"
 description = "High-performance Rust proxy bridging Godot's TCP Language Server to Stdio for Claude Code"
 license     = "MPL-2.0"

--- a/README.md
+++ b/README.md
@@ -7,7 +7,7 @@
 └──────────────────────────────────────────────┘
 ```
 
-Full GDScript code intelligence — go-to-definition, hover docs, completions, and diagnostics — inside **Claude Code**, powered by Godot's native Language Server.
+Full GDScript code intelligence — go-to-definition, hover docs, completions, diagnostics, and **GDShader validation** — inside **Claude Code**, powered by Godot's native Language Server.
 
 ---
 
@@ -67,6 +67,7 @@ That's it. Open Godot with a project, open any `.gd` file in Claude Code, and GD
 ## Features
 
 - **Full GDScript intelligence** — go-to-definition, hover docs, completions, and diagnostics powered by Godot's native LSP
+- **GDShader diagnostics** — validates `.gdshader` files by running Godot headless, surfacing shader compilation errors as LSP diagnostics with line-accurate ranges
 - **Auto-discovery** — scans ports 6005–6014 and connects to the running Godot instance automatically
 - **Retry on startup** — exponential-backoff probe when Godot hasn't launched yet; no manual restarts needed
 - **Hot-reconnect** — detects in-session project switches and reconnects without restarting Claude Code
@@ -80,7 +81,7 @@ That's it. Open Godot with a project, open any `.gd` file in Claude Code, and GD
 
 ### Proxy flags
 
-All flags below are **stable** as of v1.0.
+All flags below are **stable** as of v1.0. Shader flags added in v1.3.
 
 | Flag | Default | Description |
 |---|---|---|
@@ -88,9 +89,11 @@ All flags below are **stable** as of v1.0.
 | `--host <ADDR>` | `127.0.0.1` | Godot LSP host |
 | `--port <N>` | *(auto-detect)* | Skip discovery; connect to explicit port |
 | `--connect-timeout <SECS>` | `300` | Max wait time for Godot to appear |
+| `--godot-path <PATH>` | *(auto-detect)* | Path to the Godot binary for shader validation |
+| `--shader-timeout <SECS>` | `10` | Timeout for the Godot shader validation subprocess |
 | `--log-level <LEVEL>` | `info` | Tracing level (`error`/`warn`/`info`/`debug`/`trace`) |
 
-Resolution order for `--host` and `--port`: CLI flag → config file → built-in default.
+Resolution order for `--host`, `--port`, and `--godot-path`: CLI flag → config file → built-in default (PATH lookup for Godot).
 
 The `RUST_LOG` environment variable is also honoured (tracing-subscriber env-filter).
 
@@ -150,16 +153,18 @@ Read or write persistent host/port defaults. Settings are stored in a JSON file 
 | macOS | `~/Library/Application Support/godot-lsp-bridge/config.json` |
 | Linux | `~/.config/godot-lsp-bridge/config.json` |
 
-Supported keys: `host`, `port`.
+Supported keys: `host`, `port`, `godot-path`.
 
 ```bash
 # Read a value (prints "(not set)" if absent)
 godot-lsp-bridge config get host
 godot-lsp-bridge config get port
+godot-lsp-bridge config get godot-path
 
 # Write a value
 godot-lsp-bridge config set host 192.168.1.10
 godot-lsp-bridge config set port 6007
+godot-lsp-bridge config set godot-path /usr/bin/godot4
 ```
 
 ---
@@ -180,7 +185,8 @@ Godot's available primitives.
 | `textDocument/documentSymbol` | Native | Symbols in current file |
 | `textDocument/signatureHelp` | Native | Function signature hints |
 | `textDocument/didOpen` / `didChange` / `didClose` | Native | Document sync |
-| `textDocument/publishDiagnostics` | Pass-through | Server-push notification; forwarded intact |
+| `textDocument/publishDiagnostics` | Pass-through | Server-push notification; forwarded intact for GDScript |
+| `.gdshader` diagnostics | **Synthesised** | Runs Godot headless to compile shaders; publishes errors as `publishDiagnostics` |
 | `workspace/symbol` | **Synthesised** | Aggregates `documentSymbol` across open files; filters by query string |
 | `textDocument/prepareCallHierarchy` | **Synthesised** | Resolves the symbol at the cursor via `documentSymbol` |
 | `callHierarchy/incomingCalls` | **Synthesised** | Finds callers via `references` at the item's selection range |
@@ -236,12 +242,6 @@ cargo nextest run --ignored
 
 # Build release
 cargo build --release
-```
-
-Or install the HEAD revision directly without cloning:
-
-```bash
-cargo install --git https://github.com/Pixel-Directive-LLC/godot-lsp-bridge
 ```
 
 </details>

--- a/src/bridge.rs
+++ b/src/bridge.rs
@@ -165,39 +165,18 @@ async fn handle_client_message(
     let params = parsed.get("params").cloned().unwrap_or(Value::Null);
 
     match method {
-        // Track open/closed files for workspace/symbol aggregation + shader diagnostics.
-        Some("textDocument/didOpen") => {
+        // Track open/closed files and trigger shader validation on open/change.
+        Some(method_name @ "textDocument/didOpen")
+        | Some(method_name @ "textDocument/didChange") => {
             if let Some(uri) = params
                 .get("textDocument")
                 .and_then(|td| td.get("uri"))
                 .and_then(Value::as_str)
             {
-                synth.lock().await.on_did_open(uri.to_owned());
-
-                // Trigger shader validation on open.
-                if shader::is_shader_uri(uri) {
-                    let uri_owned = uri.to_owned();
-                    let stdout_tx = to_stdout.clone();
-                    let shaders2 = Arc::clone(&shaders);
-                    let gp = (*godot_path).clone();
-                    let handle = tokio::spawn(shader::validate_shader(
-                        uri_owned.clone(),
-                        shader_timeout,
-                        gp,
-                        stdout_tx,
-                    ));
-                    shaders2.lock().await.register(uri_owned, handle);
+                if method_name == "textDocument/didOpen" {
+                    synth.lock().await.on_did_open(uri.to_owned());
                 }
-            }
-            let _ = to_tcp.send(msg);
-        }
-        // Trigger shader re-validation on change (debounced inside validate_shader).
-        Some("textDocument/didChange") => {
-            if let Some(uri) = params
-                .get("textDocument")
-                .and_then(|td| td.get("uri"))
-                .and_then(Value::as_str)
-            {
+
                 if shader::is_shader_uri(uri) {
                     let uri_owned = uri.to_owned();
                     let stdout_tx = to_stdout.clone();

--- a/src/bridge.rs
+++ b/src/bridge.rs
@@ -42,7 +42,11 @@ pub enum RunOutcome {
 ///
 /// A graceful OS shutdown signal also terminates the loop and returns
 /// [`RunOutcome::StdinClosed`] (treated as a clean exit).
-pub async fn run(stream: TcpStream, shader_timeout: Duration) -> Result<RunOutcome> {
+pub async fn run(
+    stream: TcpStream,
+    shader_timeout: Duration,
+    godot_path: Option<String>,
+) -> Result<RunOutcome> {
     let (tcp_rx, tcp_tx) = stream.into_split();
 
     // Channel: messages destined for the Godot TCP socket.
@@ -52,6 +56,7 @@ pub async fn run(stream: TcpStream, shader_timeout: Duration) -> Result<RunOutco
 
     let synth = Arc::new(Mutex::new(Synthesizer::new()));
     let shaders = Arc::new(Mutex::new(ShaderState::default()));
+    let godot_path = Arc::new(godot_path);
 
     let outcome = tokio::select! {
         outcome = stdin_loop(
@@ -59,6 +64,7 @@ pub async fn run(stream: TcpStream, shader_timeout: Duration) -> Result<RunOutco
             Arc::clone(&synth),
             Arc::clone(&shaders),
             shader_timeout,
+            Arc::clone(&godot_path),
             to_tcp_tx.clone(),
             to_stdout_tx.clone(),
         ) => outcome,
@@ -100,6 +106,7 @@ async fn stdin_loop(
     synth: Arc<Mutex<Synthesizer>>,
     shaders: Arc<Mutex<ShaderState>>,
     shader_timeout: Duration,
+    godot_path: Arc<Option<String>>,
     to_tcp: mpsc::UnboundedSender<Vec<u8>>,
     to_stdout: mpsc::UnboundedSender<Vec<u8>>,
 ) -> RunOutcome {
@@ -111,6 +118,7 @@ async fn stdin_loop(
                     Arc::clone(&synth),
                     Arc::clone(&shaders),
                     shader_timeout,
+                    Arc::clone(&godot_path),
                     &to_tcp,
                     &to_stdout,
                 )
@@ -139,6 +147,7 @@ async fn handle_client_message(
     synth: Arc<Mutex<Synthesizer>>,
     shaders: Arc<Mutex<ShaderState>>,
     shader_timeout: Duration,
+    godot_path: Arc<Option<String>>,
     to_tcp: &mpsc::UnboundedSender<Vec<u8>>,
     to_stdout: &mpsc::UnboundedSender<Vec<u8>>,
 ) {
@@ -170,9 +179,11 @@ async fn handle_client_message(
                     let uri_owned = uri.to_owned();
                     let stdout_tx = to_stdout.clone();
                     let shaders2 = Arc::clone(&shaders);
+                    let gp = (*godot_path).clone();
                     let handle = tokio::spawn(shader::validate_shader(
                         uri_owned.clone(),
                         shader_timeout,
+                        gp,
                         stdout_tx,
                     ));
                     shaders2.lock().await.register(uri_owned, handle);
@@ -191,9 +202,11 @@ async fn handle_client_message(
                     let uri_owned = uri.to_owned();
                     let stdout_tx = to_stdout.clone();
                     let shaders2 = Arc::clone(&shaders);
+                    let gp = (*godot_path).clone();
                     let handle = tokio::spawn(shader::validate_shader(
                         uri_owned.clone(),
                         shader_timeout,
+                        gp,
                         stdout_tx,
                     ));
                     shaders2.lock().await.register(uri_owned, handle);

--- a/src/bridge.rs
+++ b/src/bridge.rs
@@ -14,10 +14,12 @@
 //! (TCP closed) or exit (stdin closed).
 
 use crate::framing;
+use crate::shader::{self, ShaderState};
 use crate::synthesizer::Synthesizer;
 use anyhow::Result;
 use serde_json::Value;
 use std::sync::Arc;
+use std::time::Duration;
 use tokio::io::{self, BufReader, BufWriter};
 use tokio::net::tcp::{OwnedReadHalf, OwnedWriteHalf};
 use tokio::net::TcpStream;
@@ -40,7 +42,7 @@ pub enum RunOutcome {
 ///
 /// A graceful OS shutdown signal also terminates the loop and returns
 /// [`RunOutcome::StdinClosed`] (treated as a clean exit).
-pub async fn run(stream: TcpStream) -> Result<RunOutcome> {
+pub async fn run(stream: TcpStream, shader_timeout: Duration) -> Result<RunOutcome> {
     let (tcp_rx, tcp_tx) = stream.into_split();
 
     // Channel: messages destined for the Godot TCP socket.
@@ -49,11 +51,14 @@ pub async fn run(stream: TcpStream) -> Result<RunOutcome> {
     let (to_stdout_tx, to_stdout_rx) = mpsc::unbounded_channel::<Vec<u8>>();
 
     let synth = Arc::new(Mutex::new(Synthesizer::new()));
+    let shaders = Arc::new(Mutex::new(ShaderState::default()));
 
     let outcome = tokio::select! {
         outcome = stdin_loop(
             BufReader::new(io::stdin()),
             Arc::clone(&synth),
+            Arc::clone(&shaders),
+            shader_timeout,
             to_tcp_tx.clone(),
             to_stdout_tx.clone(),
         ) => outcome,
@@ -93,13 +98,23 @@ pub async fn run(stream: TcpStream) -> Result<RunOutcome> {
 async fn stdin_loop(
     mut stdin: BufReader<io::Stdin>,
     synth: Arc<Mutex<Synthesizer>>,
+    shaders: Arc<Mutex<ShaderState>>,
+    shader_timeout: Duration,
     to_tcp: mpsc::UnboundedSender<Vec<u8>>,
     to_stdout: mpsc::UnboundedSender<Vec<u8>>,
 ) -> RunOutcome {
     loop {
         match framing::read_message(&mut stdin).await {
             Ok(Some(msg)) => {
-                handle_client_message(msg, Arc::clone(&synth), &to_tcp, &to_stdout).await;
+                handle_client_message(
+                    msg,
+                    Arc::clone(&synth),
+                    Arc::clone(&shaders),
+                    shader_timeout,
+                    &to_tcp,
+                    &to_stdout,
+                )
+                .await;
             }
             Ok(None) => return RunOutcome::StdinClosed,
             Err(e) => {
@@ -113,12 +128,17 @@ async fn stdin_loop(
 /// Inspect and route one client message.
 ///
 /// - `textDocument/didOpen` / `didClose`: update open-file state, then pass through.
+///   For `.gdshader` files, also trigger shader validation or clear diagnostics.
+/// - `textDocument/didChange`: pass through; for `.gdshader` files, trigger debounced
+///   re-validation.
 /// - `workspace/symbol`, `prepareCallHierarchy`, `callHierarchy/*`: intercept and
 ///   spawn a synthesis task.
 /// - Everything else: pass through unchanged.
 async fn handle_client_message(
     msg: Vec<u8>,
     synth: Arc<Mutex<Synthesizer>>,
+    shaders: Arc<Mutex<ShaderState>>,
+    shader_timeout: Duration,
     to_tcp: &mpsc::UnboundedSender<Vec<u8>>,
     to_stdout: &mpsc::UnboundedSender<Vec<u8>>,
 ) {
@@ -136,7 +156,7 @@ async fn handle_client_message(
     let params = parsed.get("params").cloned().unwrap_or(Value::Null);
 
     match method {
-        // Track open/closed files for workspace/symbol aggregation.
+        // Track open/closed files for workspace/symbol aggregation + shader diagnostics.
         Some("textDocument/didOpen") => {
             if let Some(uri) = params
                 .get("textDocument")
@@ -144,6 +164,40 @@ async fn handle_client_message(
                 .and_then(Value::as_str)
             {
                 synth.lock().await.on_did_open(uri.to_owned());
+
+                // Trigger shader validation on open.
+                if shader::is_shader_uri(uri) {
+                    let uri_owned = uri.to_owned();
+                    let stdout_tx = to_stdout.clone();
+                    let shaders2 = Arc::clone(&shaders);
+                    let handle = tokio::spawn(shader::validate_shader(
+                        uri_owned.clone(),
+                        shader_timeout,
+                        stdout_tx,
+                    ));
+                    shaders2.lock().await.register(uri_owned, handle);
+                }
+            }
+            let _ = to_tcp.send(msg);
+        }
+        // Trigger shader re-validation on change (debounced inside validate_shader).
+        Some("textDocument/didChange") => {
+            if let Some(uri) = params
+                .get("textDocument")
+                .and_then(|td| td.get("uri"))
+                .and_then(Value::as_str)
+            {
+                if shader::is_shader_uri(uri) {
+                    let uri_owned = uri.to_owned();
+                    let stdout_tx = to_stdout.clone();
+                    let shaders2 = Arc::clone(&shaders);
+                    let handle = tokio::spawn(shader::validate_shader(
+                        uri_owned.clone(),
+                        shader_timeout,
+                        stdout_tx,
+                    ));
+                    shaders2.lock().await.register(uri_owned, handle);
+                }
             }
             let _ = to_tcp.send(msg);
         }
@@ -154,6 +208,12 @@ async fn handle_client_message(
                 .and_then(Value::as_str)
             {
                 synth.lock().await.on_did_close(uri);
+
+                // Clear shader diagnostics and cancel any in-flight validation.
+                if shader::is_shader_uri(uri) {
+                    shaders.lock().await.remove(uri);
+                    shader::clear_diagnostics(uri, to_stdout);
+                }
             }
             let _ = to_tcp.send(msg);
         }

--- a/src/config.rs
+++ b/src/config.rs
@@ -17,6 +17,9 @@ pub struct Config {
     pub host: Option<String>,
     /// Persistent port override (equivalent to `--port`).
     pub port: Option<u16>,
+    /// Path to the Godot binary (equivalent to `--godot-path`).
+    #[serde(rename = "godot-path")]
+    pub godot_path: Option<String>,
 }
 
 /// Returns the platform-appropriate config file path.
@@ -65,7 +68,11 @@ pub fn get(key: &str) -> Result<()> {
             Some(v) => println!("{v}"),
             None => println!("(not set)"),
         },
-        _ => anyhow::bail!("unknown key {key:?}; valid keys: host, port"),
+        "godot-path" => match cfg.godot_path {
+            Some(v) => println!("{v}"),
+            None => println!("(not set)"),
+        },
+        _ => anyhow::bail!("unknown key {key:?}; valid keys: host, port, godot-path"),
     }
     Ok(())
 }
@@ -81,7 +88,8 @@ pub fn set(key: &str, value: &str) -> Result<()> {
                 .with_context(|| format!("invalid port {value:?}: must be a number 1–65535"))?;
             cfg.port = Some(port);
         }
-        _ => anyhow::bail!("unknown key {key:?}; valid keys: host, port"),
+        "godot-path" => cfg.godot_path = Some(value.to_owned()),
+        _ => anyhow::bail!("unknown key {key:?}; valid keys: host, port, godot-path"),
     }
     save(&cfg)?;
     let path = config_path()?;

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -7,4 +7,5 @@
 pub mod bridge;
 pub mod discovery;
 pub mod framing;
+pub mod shader;
 pub mod synthesizer;

--- a/src/main.rs
+++ b/src/main.rs
@@ -47,6 +47,11 @@ struct Cli {
     #[arg(long, default_value_t = DEFAULT_RETRY_TIMEOUT.as_secs())]
     connect_timeout: u64,
 
+    /// Path to the Godot binary for shader validation. When omitted, looks up the
+    /// config file and then PATH.
+    #[arg(long)]
+    godot_path: Option<String>,
+
     /// Timeout in seconds for the Godot shader validation subprocess [default: 10].
     #[arg(long, default_value_t = 10)]
     shader_timeout: u64,
@@ -127,6 +132,12 @@ async fn main() -> Result<()> {
     let timeout = Duration::from_secs(cli.connect_timeout);
     let shader_timeout = Duration::from_secs(cli.shader_timeout);
 
+    // Resolve Godot binary: CLI flag → config file → PATH lookup.
+    let godot_path = cli
+        .godot_path
+        .or(cfg.godot_path)
+        .or_else(resolve_godot_on_path);
+
     let port = match port_override {
         Some(p) => {
             info!("Using explicit port {p}; skipping auto-discovery");
@@ -140,7 +151,7 @@ async fn main() -> Result<()> {
         let stream = connect_with_backoff(&host, port, timeout).await?;
         info!("Bridging stdio <=> {host}:{port}");
 
-        match bridge::run(stream, shader_timeout).await? {
+        match bridge::run(stream, shader_timeout, godot_path.clone()).await? {
             RunOutcome::StdinClosed => {
                 info!("Editor closed stdin — exiting");
                 break;
@@ -169,6 +180,25 @@ impl Cli {
     fn port_or_config(&self, config_port: Option<u16>) -> u16 {
         self.port.or(config_port).unwrap_or(6005)
     }
+}
+
+/// Check if `godot` (or `godot.exe` on Windows) is on PATH.
+fn resolve_godot_on_path() -> Option<String> {
+    let names: &[&str] = if cfg!(windows) {
+        &["godot.exe", "godot.bat", "godot.cmd", "godot"]
+    } else {
+        &["godot"]
+    };
+    let path_var = std::env::var_os("PATH")?;
+    for dir in std::env::split_paths(&path_var) {
+        for name in names {
+            let candidate = dir.join(name);
+            if candidate.is_file() {
+                return Some(candidate.to_string_lossy().into_owned());
+            }
+        }
+    }
+    None
 }
 
 /// Scan candidate ports and return the port to connect to.
@@ -227,6 +257,18 @@ mod tests {
     fn shader_timeout_parsed() {
         let cli = Cli::parse_from(["godot-lsp-bridge", "--shader-timeout", "30"]);
         assert_eq!(cli.shader_timeout, 30);
+    }
+
+    #[test]
+    fn godot_path_parsed() {
+        let cli = Cli::parse_from(["godot-lsp-bridge", "--godot-path", "/usr/bin/godot4"]);
+        assert_eq!(cli.godot_path.as_deref(), Some("/usr/bin/godot4"));
+    }
+
+    #[test]
+    fn godot_path_default_is_none() {
+        let cli = Cli::parse_from(["godot-lsp-bridge"]);
+        assert!(cli.godot_path.is_none());
     }
 
     #[test]

--- a/src/main.rs
+++ b/src/main.rs
@@ -47,6 +47,10 @@ struct Cli {
     #[arg(long, default_value_t = DEFAULT_RETRY_TIMEOUT.as_secs())]
     connect_timeout: u64,
 
+    /// Timeout in seconds for the Godot shader validation subprocess [default: 10].
+    #[arg(long, default_value_t = 10)]
+    shader_timeout: u64,
+
     /// Tracing log level (error, warn, info, debug, or trace).
     #[arg(long, default_value = "info")]
     log_level: String,
@@ -121,6 +125,7 @@ async fn main() -> Result<()> {
     let host = cli.host_or_config(cfg.host.as_deref());
     let port_override = cli.port.or(cfg.port);
     let timeout = Duration::from_secs(cli.connect_timeout);
+    let shader_timeout = Duration::from_secs(cli.shader_timeout);
 
     let port = match port_override {
         Some(p) => {
@@ -135,7 +140,7 @@ async fn main() -> Result<()> {
         let stream = connect_with_backoff(&host, port, timeout).await?;
         info!("Bridging stdio <=> {host}:{port}");
 
-        match bridge::run(stream).await? {
+        match bridge::run(stream, shader_timeout).await? {
             RunOutcome::StdinClosed => {
                 info!("Editor closed stdin — exiting");
                 break;
@@ -213,8 +218,15 @@ mod tests {
         assert!(cli.host.is_none());
         assert!(cli.port.is_none());
         assert_eq!(cli.connect_timeout, DEFAULT_RETRY_TIMEOUT.as_secs());
+        assert_eq!(cli.shader_timeout, 10);
         assert_eq!(cli.log_level, "info");
         assert!(cli.command.is_none());
+    }
+
+    #[test]
+    fn shader_timeout_parsed() {
+        let cli = Cli::parse_from(["godot-lsp-bridge", "--shader-timeout", "30"]);
+        assert_eq!(cli.shader_timeout, 30);
     }
 
     #[test]

--- a/src/shader.rs
+++ b/src/shader.rs
@@ -178,21 +178,13 @@ async fn run_godot_validation(
     script_file.flush()?;
     let script_path = script_file.path().to_path_buf();
 
-    // Resolve the res:// path relative to the project.
-    // The shader file_path is an absolute OS path.  Godot's --script loads from the
-    // filesystem, but the shader itself must be referenced as a res:// path so that
-    // Godot's resource loader can find it within the project.
+    // The shader file_path is an absolute OS path. Godot's `load()` function,
+    // which is used by the validation script, requires a `res://` path to find
+    // the resource within the project.
     //
-    // We pass the absolute path and let the script use it directly — Godot's load()
-    // accepts res:// paths, so we need to figure out the project root.
-    // For simplicity, we pass the OS path and let the user's project.godot handle it.
-    // Actually, the script receives the path via OS.get_cmdline_user_args(), and load()
-    // requires a res:// path.  We'll pass the absolute path and have Godot try to
-    // resolve it.  If the file is within a Godot project, load() with an absolute path
-    // won't work — we need the res:// path.
-    //
-    // Strategy: find the nearest project.godot ancestor, compute the relative path,
-    // and prefix with "res://".
+    // To resolve this, we find the nearest `project.godot` ancestor to determine
+    // the project root, compute the relative path from there, and prefix it
+    // with "res://".
     let res_path = to_res_path(file_path)?;
 
     // Find the project root (directory containing project.godot) for --path.
@@ -398,44 +390,29 @@ fn strip_ansi(s: &str) -> String {
 /// Convert a `file://` URI to a local filesystem path.
 ///
 /// Handles percent-decoding and the Windows `file:///C:/...` convention.
+/// Uses case-insensitive scheme matching for robustness.
 pub fn uri_to_path(uri: &str) -> Option<PathBuf> {
-    let path_str = uri.strip_prefix("file://")?;
+    let (scheme, path_str) = uri.split_once("://")?;
+    if !scheme.eq_ignore_ascii_case("file") {
+        return None;
+    }
 
-    // Percent-decode.
-    let decoded = percent_decode(path_str);
+    let decoded = percent_encoding::percent_decode_str(path_str).decode_utf8_lossy();
 
     // On Windows, file:///C:/foo → /C:/foo — strip leading slash before drive letter.
     #[cfg(windows)]
     {
-        let trimmed = decoded.strip_prefix('/').unwrap_or(&decoded);
+        let decoded_str = decoded.as_ref();
+        let trimmed = decoded_str.strip_prefix('/').unwrap_or(decoded_str);
         if trimmed.len() >= 2 && trimmed.as_bytes()[1] == b':' {
             return Some(PathBuf::from(trimmed));
         }
-        Some(PathBuf::from(&decoded))
+        Some(PathBuf::from(decoded_str))
     }
     #[cfg(not(windows))]
     {
-        Some(PathBuf::from(&decoded))
+        Some(PathBuf::from(decoded.as_ref()))
     }
-}
-
-/// Minimal percent-decoding for file URIs.
-fn percent_decode(s: &str) -> String {
-    let mut out = String::with_capacity(s.len());
-    let bytes = s.as_bytes();
-    let mut i = 0;
-    while i < bytes.len() {
-        if bytes[i] == b'%' && i + 2 < bytes.len() {
-            if let Ok(byte) = u8::from_str_radix(&s[i + 1..i + 3], 16) {
-                out.push(byte as char);
-                i += 3;
-                continue;
-            }
-        }
-        out.push(bytes[i] as char);
-        i += 1;
-    }
-    out
 }
 
 // ── Tests ────────────────────────────────────────────────────────────────────
@@ -554,16 +531,10 @@ res://test.gdshader:8 - Unknown identifier in expression: 'xx'. Shader compilati
         assert!(uri_to_path("https://example.com").is_none());
     }
 
-    // ── percent_decode ───────────────────────────────────────────────────────
-
     #[test]
-    fn percent_decode_spaces() {
-        assert_eq!(percent_decode("hello%20world"), "hello world");
-    }
-
-    #[test]
-    fn percent_decode_no_encoding() {
-        assert_eq!(percent_decode("hello"), "hello");
+    fn uri_to_path_case_insensitive_scheme() {
+        let p = uri_to_path("FILE:///home/user/test.gdshader");
+        assert!(p.is_some());
     }
 
     // ── extract_line_from_location ───────────────────────────────────────────

--- a/src/shader.rs
+++ b/src/shader.rs
@@ -1,0 +1,566 @@
+//! Synthesised diagnostics for `.gdshader` files.
+//!
+//! Godot's native LSP only serves diagnostics for GDScript.  This module fills the gap
+//! by spawning Godot in headless mode with a small validation script, capturing stderr,
+//! and converting shader compilation errors into `textDocument/publishDiagnostics`
+//! notifications.
+//!
+//! The embedded GDScript ([`VALIDATE_SCRIPT`]) is written to a temp file at runtime,
+//! executed via `godot --headless --script`, and cleaned up automatically.
+
+use crate::synthesizer::make_notification;
+use serde_json::{json, Value};
+use std::collections::HashMap;
+use std::path::{Path, PathBuf};
+use std::time::Duration;
+use tokio::sync::mpsc;
+use tokio::task::JoinHandle;
+use tracing::{debug, warn};
+
+/// GDScript that loads a shader file to trigger compilation diagnostics on stderr.
+///
+/// Usage: `godot --headless --script <this_file> -- <shader_res_path>`
+///
+/// The script loads the shader via `load()`, which forces Godot's shader compiler to
+/// run.  Any compilation errors are printed to stderr in Godot's standard format.
+/// The script then exits immediately.
+const VALIDATE_SCRIPT: &str = r#"@tool
+extends SceneTree
+
+func _init() -> void:
+    var args := OS.get_cmdline_user_args()
+    if args.size() == 0:
+        push_error("validate_shader: no shader path argument")
+        quit(1)
+        return
+    var shader_path := args[0]
+    var shader := load(shader_path)
+    if shader == null:
+        push_error("validate_shader: failed to load " + shader_path)
+        quit(1)
+        return
+    quit(0)
+"#;
+
+/// Tracks in-flight shader validation tasks so they can be cancelled on re-edit.
+#[derive(Default)]
+pub struct ShaderState {
+    /// Map from shader URI to the running validation task handle.
+    pending: HashMap<String, JoinHandle<()>>,
+}
+
+impl ShaderState {
+    /// Cancel any in-flight validation for `uri`.
+    pub fn cancel(&mut self, uri: &str) {
+        if let Some(handle) = self.pending.remove(uri) {
+            handle.abort();
+        }
+    }
+
+    /// Register a new validation task for `uri`, cancelling any previous one.
+    pub fn register(&mut self, uri: String, handle: JoinHandle<()>) {
+        self.cancel(&uri);
+        self.pending.insert(uri, handle);
+    }
+
+    /// Remove tracking for `uri` (called on `didClose`).
+    pub fn remove(&mut self, uri: &str) {
+        self.cancel(uri);
+    }
+}
+
+// ── Diagnostics synthesis ────────────────────────────────────────────────────
+
+/// Debounce delay before launching Godot for shader validation.
+const DEBOUNCE_MS: u64 = 300;
+
+/// Validate a shader file by running Godot headless and publish diagnostics.
+///
+/// This is spawned as a background task from the bridge.  It sleeps for the debounce
+/// period first, giving the user time to finish typing before we spawn a subprocess.
+pub async fn validate_shader(
+    uri: String,
+    timeout: Duration,
+    to_stdout: mpsc::UnboundedSender<Vec<u8>>,
+) {
+    // Debounce — if the task is aborted during this sleep, no subprocess is spawned.
+    tokio::time::sleep(Duration::from_millis(DEBOUNCE_MS)).await;
+
+    let file_path = match uri_to_path(&uri) {
+        Some(p) => p,
+        None => {
+            warn!("shader: cannot convert URI to path: {uri}");
+            return;
+        }
+    };
+
+    let diagnostics = match run_godot_validation(&file_path, timeout).await {
+        Ok(diags) => diags,
+        Err(e) => {
+            warn!("shader: validation failed for {uri}: {e}");
+            // Publish empty diagnostics to clear any stale errors.
+            Vec::new()
+        }
+    };
+
+    let notification = make_notification(
+        "textDocument/publishDiagnostics",
+        json!({
+            "uri": uri,
+            "diagnostics": diagnostics,
+        }),
+    );
+    let _ = to_stdout.send(notification);
+}
+
+/// Build and send a `publishDiagnostics` notification with an empty diagnostics array.
+pub fn clear_diagnostics(uri: &str, to_stdout: &mpsc::UnboundedSender<Vec<u8>>) {
+    let notification = make_notification(
+        "textDocument/publishDiagnostics",
+        json!({
+            "uri": uri,
+            "diagnostics": [],
+        }),
+    );
+    let _ = to_stdout.send(notification);
+}
+
+/// Returns `true` if `uri` points to a `.gdshader` file.
+pub fn is_shader_uri(uri: &str) -> bool {
+    uri.ends_with(".gdshader")
+}
+
+// ── Godot subprocess ─────────────────────────────────────────────────────────
+
+/// Write the validation script to a temp file, run Godot headless, and parse stderr.
+async fn run_godot_validation(file_path: &Path, timeout: Duration) -> anyhow::Result<Vec<Value>> {
+    use std::io::Write;
+    use tokio::process::Command;
+
+    // Write the embedded script to a temp file.
+    let mut script_file = tempfile::Builder::new()
+        .prefix("glb_shader_")
+        .suffix(".gd")
+        .tempfile()?;
+    script_file.write_all(VALIDATE_SCRIPT.as_bytes())?;
+    script_file.flush()?;
+    let script_path = script_file.path().to_path_buf();
+
+    // Resolve the res:// path relative to the project.
+    // The shader file_path is an absolute OS path.  Godot's --script loads from the
+    // filesystem, but the shader itself must be referenced as a res:// path so that
+    // Godot's resource loader can find it within the project.
+    //
+    // We pass the absolute path and let the script use it directly — Godot's load()
+    // accepts res:// paths, so we need to figure out the project root.
+    // For simplicity, we pass the OS path and let the user's project.godot handle it.
+    // Actually, the script receives the path via OS.get_cmdline_user_args(), and load()
+    // requires a res:// path.  We'll pass the absolute path and have Godot try to
+    // resolve it.  If the file is within a Godot project, load() with an absolute path
+    // won't work — we need the res:// path.
+    //
+    // Strategy: find the nearest project.godot ancestor, compute the relative path,
+    // and prefix with "res://".
+    let res_path = to_res_path(file_path)?;
+
+    // Find the project root (directory containing project.godot) for --path.
+    let project_root = find_project_root(file_path)
+        .ok_or_else(|| anyhow::anyhow!("no project.godot found above {}", file_path.display()))?;
+
+    let mut cmd = Command::new("godot");
+    cmd.arg("--headless")
+        .arg("--path")
+        .arg(&project_root)
+        .arg("--script")
+        .arg(script_path.to_string_lossy().as_ref())
+        .arg("--")
+        .arg(&res_path)
+        .stdout(std::process::Stdio::null())
+        .stderr(std::process::Stdio::piped());
+
+    debug!(
+        "shader: running godot --headless --path {} --script {} -- {res_path}",
+        project_root.display(),
+        script_path.display()
+    );
+
+    let output = tokio::time::timeout(timeout, cmd.output()).await??;
+
+    let stderr = String::from_utf8_lossy(&output.stderr);
+    debug!("shader: godot stderr ({} bytes): {stderr}", stderr.len());
+
+    Ok(parse_shader_errors(&stderr))
+}
+
+/// Walk up from `path` to find the directory containing `project.godot`.
+fn find_project_root(path: &Path) -> Option<PathBuf> {
+    let mut dir = if path.is_file() { path.parent()? } else { path };
+    loop {
+        if dir.join("project.godot").exists() {
+            return Some(dir.to_path_buf());
+        }
+        dir = dir.parent()?;
+    }
+}
+
+/// Convert an absolute file path to a `res://` path relative to the project root.
+fn to_res_path(file_path: &Path) -> anyhow::Result<String> {
+    let project_root = find_project_root(file_path)
+        .ok_or_else(|| anyhow::anyhow!("no project.godot found above {}", file_path.display()))?;
+    let relative = file_path
+        .strip_prefix(&project_root)
+        .map_err(|_| anyhow::anyhow!("shader path not inside project root"))?;
+    // Use forward slashes for res:// paths.
+    let rel_str = relative.to_string_lossy().replace('\\', "/");
+    Ok(format!("res://{rel_str}"))
+}
+
+// ── Stderr parsing ───────────────────────────────────────────────────────────
+
+/// Parse Godot's stderr output into LSP `Diagnostic` objects.
+///
+/// Recognises two formats:
+///
+/// 1. **Shader compilation errors:**
+///    `res://path.gdshader:LINE - MESSAGE. Shader compilation failed.`
+///
+/// 2. **Engine errors (with optional ANSI codes):**
+///    `ERROR: MESSAGE at: FUNCTION (FILE:LINE)`
+pub fn parse_shader_errors(stderr: &str) -> Vec<Value> {
+    let mut diagnostics = Vec::new();
+
+    for line in stderr.lines() {
+        // Strip ANSI escape sequences for reliable matching.
+        let clean = strip_ansi(line);
+
+        // Format 1: res://path.gdshader:LINE - MESSAGE
+        if let Some(diag) = parse_shader_compilation_line(&clean) {
+            diagnostics.push(diag);
+            continue;
+        }
+
+        // Format 2: ERROR: MESSAGE at: FUNCTION (FILE:LINE)
+        if let Some(diag) = parse_engine_error_line(&clean) {
+            diagnostics.push(diag);
+        }
+    }
+
+    diagnostics
+}
+
+/// Parse a shader compilation error line.
+///
+/// Format: `res://path.gdshader:LINE - MESSAGE[. Shader compilation failed.]`
+fn parse_shader_compilation_line(line: &str) -> Option<Value> {
+    // Match: starts with res://, has :LINE, then " - " separator.
+    let rest = line.strip_prefix("res://")?;
+    let colon_pos = rest.find(':')?;
+    let after_colon = &rest[colon_pos + 1..];
+
+    // Extract line number — digits up to the next non-digit.
+    let line_end = after_colon
+        .find(|c: char| !c.is_ascii_digit())
+        .unwrap_or(after_colon.len());
+    if line_end == 0 {
+        return None;
+    }
+    let line_num: u32 = after_colon[..line_end].parse().ok()?;
+
+    // The message follows " - ".
+    let msg_start = after_colon.find(" - ")?;
+    let mut message = after_colon[msg_start + 3..].trim().to_owned();
+
+    // Strip trailing "Shader compilation failed." if present.
+    if let Some(stripped) = message.strip_suffix("Shader compilation failed.") {
+        message = stripped.trim().trim_end_matches('.').to_owned();
+    }
+
+    if message.is_empty() {
+        return None;
+    }
+
+    // LSP lines are 0-based; Godot reports 1-based.
+    let lsp_line = line_num.saturating_sub(1);
+
+    Some(json!({
+        "range": {
+            "start": { "line": lsp_line, "character": 0 },
+            "end":   { "line": lsp_line, "character": 0 },
+        },
+        "severity": 1,
+        "source": "gdshader",
+        "message": message,
+    }))
+}
+
+/// Parse an engine ERROR: line.
+///
+/// Format: `ERROR: MESSAGE at: FUNCTION (FILE:LINE)`
+fn parse_engine_error_line(line: &str) -> Option<Value> {
+    let rest = line.strip_prefix("ERROR: ")?.trim();
+
+    // We only care about shader-related engine errors.
+    // Look for " at: " separator.
+    let at_pos = rest.find(" at: ")?;
+    let message = rest[..at_pos].trim();
+
+    // Skip generic engine errors that aren't shader-related.
+    let lower = message.to_ascii_lowercase();
+    if !lower.contains("shader")
+        && !lower.contains("compile")
+        && !lower.contains("parse")
+        && !lower.contains("validate_shader")
+    {
+        return None;
+    }
+
+    // Try to extract line number from the " at: func (file:line)" suffix.
+    let location = &rest[at_pos + 5..];
+    let line_num = extract_line_from_location(location).unwrap_or(0);
+    let lsp_line = if line_num > 0 { line_num - 1 } else { 0 };
+
+    Some(json!({
+        "range": {
+            "start": { "line": lsp_line, "character": 0 },
+            "end":   { "line": lsp_line, "character": 0 },
+        },
+        "severity": 1,
+        "source": "gdshader",
+        "message": message,
+    }))
+}
+
+/// Extract a line number from a Godot error location string like `func_name (file.cpp:123)`.
+fn extract_line_from_location(location: &str) -> Option<u32> {
+    let paren_start = location.rfind('(')?;
+    let paren_end = location.rfind(')')?;
+    if paren_end <= paren_start {
+        return None;
+    }
+    let inner = &location[paren_start + 1..paren_end];
+    let colon = inner.rfind(':')?;
+    inner[colon + 1..].parse().ok()
+}
+
+/// Strip ANSI escape sequences from a string.
+fn strip_ansi(s: &str) -> String {
+    let mut out = String::with_capacity(s.len());
+    let mut chars = s.chars();
+    while let Some(c) = chars.next() {
+        if c == '\x1b' {
+            // Skip until we hit a letter (the terminator of the escape sequence).
+            for esc_c in chars.by_ref() {
+                if esc_c.is_ascii_alphabetic() {
+                    break;
+                }
+            }
+        } else {
+            out.push(c);
+        }
+    }
+    out
+}
+
+// ── URI / path conversion ────────────────────────────────────────────────────
+
+/// Convert a `file://` URI to a local filesystem path.
+///
+/// Handles percent-decoding and the Windows `file:///C:/...` convention.
+pub fn uri_to_path(uri: &str) -> Option<PathBuf> {
+    let path_str = uri.strip_prefix("file://")?;
+
+    // Percent-decode.
+    let decoded = percent_decode(path_str);
+
+    // On Windows, file:///C:/foo → /C:/foo — strip leading slash before drive letter.
+    #[cfg(windows)]
+    {
+        let trimmed = decoded.strip_prefix('/').unwrap_or(&decoded);
+        if trimmed.len() >= 2 && trimmed.as_bytes()[1] == b':' {
+            return Some(PathBuf::from(trimmed));
+        }
+        Some(PathBuf::from(&decoded))
+    }
+    #[cfg(not(windows))]
+    {
+        Some(PathBuf::from(&decoded))
+    }
+}
+
+/// Minimal percent-decoding for file URIs.
+fn percent_decode(s: &str) -> String {
+    let mut out = String::with_capacity(s.len());
+    let bytes = s.as_bytes();
+    let mut i = 0;
+    while i < bytes.len() {
+        if bytes[i] == b'%' && i + 2 < bytes.len() {
+            if let Ok(byte) = u8::from_str_radix(&s[i + 1..i + 3], 16) {
+                out.push(byte as char);
+                i += 3;
+                continue;
+            }
+        }
+        out.push(bytes[i] as char);
+        i += 1;
+    }
+    out
+}
+
+// ── Tests ────────────────────────────────────────────────────────────────────
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    // ── parse_shader_errors ──────────────────────────────────────────────────
+
+    #[test]
+    fn parse_empty_stderr_returns_no_diagnostics() {
+        assert!(parse_shader_errors("").is_empty());
+    }
+
+    #[test]
+    fn parse_valid_shader_output_returns_no_diagnostics() {
+        let stderr = "Godot Engine v4.4.stable - https://godotengine.org\n";
+        assert!(parse_shader_errors(stderr).is_empty());
+    }
+
+    #[test]
+    fn parse_shader_compilation_error() {
+        let stderr = "res://test.gdshader:8 - Unknown identifier in expression: 'xx'. Shader compilation failed.";
+        let diags = parse_shader_errors(stderr);
+        assert_eq!(diags.len(), 1);
+        assert_eq!(diags[0]["range"]["start"]["line"], 7); // 0-based
+        assert_eq!(diags[0]["severity"], 1);
+        assert_eq!(
+            diags[0]["message"],
+            "Unknown identifier in expression: 'xx'"
+        );
+        assert_eq!(diags[0]["source"], "gdshader");
+    }
+
+    #[test]
+    fn parse_multiple_shader_errors() {
+        let stderr = "\
+res://test.gdshader:3 - Expected valid type hint after ':'. Shader compilation failed.\n\
+res://test.gdshader:8 - Unknown identifier in expression: 'xx'. Shader compilation failed.";
+        let diags = parse_shader_errors(stderr);
+        assert_eq!(diags.len(), 2);
+        assert_eq!(diags[0]["range"]["start"]["line"], 2);
+        assert_eq!(diags[1]["range"]["start"]["line"], 7);
+    }
+
+    #[test]
+    fn parse_engine_error_with_shader_keyword() {
+        let stderr =
+            "ERROR: Shader compilation error at: compile_shader (servers/rendering.cpp:123)";
+        let diags = parse_shader_errors(stderr);
+        assert_eq!(diags.len(), 1);
+        assert!(diags[0]["message"]
+            .as_str()
+            .unwrap()
+            .contains("Shader compilation error"));
+    }
+
+    #[test]
+    fn parse_engine_error_without_shader_keyword_ignored() {
+        let stderr = "ERROR: Some random engine error at: do_thing (core/main.cpp:50)";
+        assert!(parse_shader_errors(stderr).is_empty());
+    }
+
+    #[test]
+    fn parse_ansi_coded_error() {
+        let stderr =
+            "\x1b[1;31mERROR: \x1b[0;91mShader parse failed\x1b[0;90m at: compile (render.cpp:42)";
+        let diags = parse_shader_errors(stderr);
+        assert_eq!(diags.len(), 1);
+        assert!(diags[0]["message"]
+            .as_str()
+            .unwrap()
+            .contains("Shader parse failed"));
+    }
+
+    #[test]
+    fn parse_shader_error_line_1_maps_to_lsp_line_0() {
+        let stderr = "res://shader.gdshader:1 - Unexpected token. Shader compilation failed.";
+        let diags = parse_shader_errors(stderr);
+        assert_eq!(diags[0]["range"]["start"]["line"], 0);
+    }
+
+    // ── strip_ansi ───────────────────────────────────────────────────────────
+
+    #[test]
+    fn strip_ansi_removes_codes() {
+        assert_eq!(strip_ansi("\x1b[1;31mERROR:\x1b[0m hello"), "ERROR: hello");
+    }
+
+    #[test]
+    fn strip_ansi_passthrough_clean_string() {
+        assert_eq!(strip_ansi("hello world"), "hello world");
+    }
+
+    // ── uri_to_path ──────────────────────────────────────────────────────────
+
+    #[test]
+    fn uri_to_path_unix_style() {
+        let p = uri_to_path("file:///home/user/project/test.gdshader");
+        assert!(p.is_some());
+        let path = p.unwrap();
+        let s = path.to_string_lossy();
+        assert!(s.contains("home") && s.contains("test.gdshader"));
+    }
+
+    #[test]
+    fn uri_to_path_percent_encoded() {
+        let p = uri_to_path("file:///path/my%20shader.gdshader");
+        assert!(p.is_some());
+        assert!(p.unwrap().to_string_lossy().contains("my shader"));
+    }
+
+    #[test]
+    fn uri_to_path_not_file_uri_returns_none() {
+        assert!(uri_to_path("https://example.com").is_none());
+    }
+
+    // ── percent_decode ───────────────────────────────────────────────────────
+
+    #[test]
+    fn percent_decode_spaces() {
+        assert_eq!(percent_decode("hello%20world"), "hello world");
+    }
+
+    #[test]
+    fn percent_decode_no_encoding() {
+        assert_eq!(percent_decode("hello"), "hello");
+    }
+
+    // ── extract_line_from_location ───────────────────────────────────────────
+
+    #[test]
+    fn extract_line_from_typical_location() {
+        assert_eq!(
+            extract_line_from_location("compile_shader (servers/rendering.cpp:123)"),
+            Some(123)
+        );
+    }
+
+    #[test]
+    fn extract_line_from_location_no_parens() {
+        assert_eq!(extract_line_from_location("no_parens"), None);
+    }
+
+    // ── ShaderState ──────────────────────────────────────────────────────────
+
+    #[test]
+    fn shader_state_cancel_noop_when_empty() {
+        let mut state = ShaderState::default();
+        state.cancel("file:///test.gdshader"); // should not panic
+    }
+
+    // ── to_res_path / find_project_root ──────────────────────────────────────
+
+    #[test]
+    fn find_project_root_returns_none_for_nonexistent() {
+        assert!(find_project_root(Path::new("/nonexistent/path/shader.gdshader")).is_none());
+    }
+}

--- a/src/shader.rs
+++ b/src/shader.rs
@@ -81,10 +81,38 @@ const DEBOUNCE_MS: u64 = 300;
 pub async fn validate_shader(
     uri: String,
     timeout: Duration,
+    godot_path: Option<String>,
     to_stdout: mpsc::UnboundedSender<Vec<u8>>,
 ) {
     // Debounce — if the task is aborted during this sleep, no subprocess is spawned.
     tokio::time::sleep(Duration::from_millis(DEBOUNCE_MS)).await;
+
+    // If there is no configured/discovered Godot binary, publish a single hint
+    // diagnostic so the AI client (or user) knows to set it up.
+    let godot_bin = match godot_path {
+        Some(p) => p,
+        None => {
+            let notification = make_notification(
+                "textDocument/publishDiagnostics",
+                json!({
+                    "uri": uri,
+                    "diagnostics": [{
+                        "range": {
+                            "start": { "line": 0, "character": 0 },
+                            "end":   { "line": 0, "character": 0 },
+                        },
+                        "severity": 3,
+                        "source": "gdshader",
+                        "message": "Shader diagnostics unavailable: Godot binary not found. \
+                            Run `godot-lsp-bridge config set godot-path /path/to/godot` \
+                            or add Godot to your PATH.",
+                    }],
+                }),
+            );
+            let _ = to_stdout.send(notification);
+            return;
+        }
+    };
 
     let file_path = match uri_to_path(&uri) {
         Some(p) => p,
@@ -94,7 +122,7 @@ pub async fn validate_shader(
         }
     };
 
-    let diagnostics = match run_godot_validation(&file_path, timeout).await {
+    let diagnostics = match run_godot_validation(&godot_bin, &file_path, timeout).await {
         Ok(diags) => diags,
         Err(e) => {
             warn!("shader: validation failed for {uri}: {e}");
@@ -133,7 +161,11 @@ pub fn is_shader_uri(uri: &str) -> bool {
 // ── Godot subprocess ─────────────────────────────────────────────────────────
 
 /// Write the validation script to a temp file, run Godot headless, and parse stderr.
-async fn run_godot_validation(file_path: &Path, timeout: Duration) -> anyhow::Result<Vec<Value>> {
+async fn run_godot_validation(
+    godot_bin: &str,
+    file_path: &Path,
+    timeout: Duration,
+) -> anyhow::Result<Vec<Value>> {
     use std::io::Write;
     use tokio::process::Command;
 
@@ -167,7 +199,7 @@ async fn run_godot_validation(file_path: &Path, timeout: Duration) -> anyhow::Re
     let project_root = find_project_root(file_path)
         .ok_or_else(|| anyhow::anyhow!("no project.godot found above {}", file_path.display()))?;
 
-    let mut cmd = Command::new("godot");
+    let mut cmd = Command::new(godot_bin);
     cmd.arg("--headless")
         .arg("--path")
         .arg(&project_root)
@@ -179,7 +211,7 @@ async fn run_godot_validation(file_path: &Path, timeout: Duration) -> anyhow::Re
         .stderr(std::process::Stdio::piped());
 
     debug!(
-        "shader: running godot --headless --path {} --script {} -- {res_path}",
+        "shader: running {godot_bin} --headless --path {} --script {} -- {res_path}",
         project_root.display(),
         script_path.display()
     );

--- a/src/synthesizer.rs
+++ b/src/synthesizer.rs
@@ -116,6 +116,16 @@ pub fn make_response(id: &Value, result: Value) -> Vec<u8> {
     .expect("infallible JSON serialisation")
 }
 
+/// Serialise a JSON-RPC notification body with `method` and `params` (no `id`).
+pub fn make_notification(method: &str, params: Value) -> Vec<u8> {
+    serde_json::to_vec(&json!({
+        "jsonrpc": "2.0",
+        "method":  method,
+        "params":  params,
+    }))
+    .expect("infallible JSON serialisation")
+}
+
 /// Serialise a JSON-RPC error response body with `id`, `code`, and `message`.
 pub fn make_error(id: &Value, code: i64, message: &str) -> Vec<u8> {
     serde_json::to_vec(&json!({
@@ -674,6 +684,18 @@ mod tests {
         let v: Value = serde_json::from_slice(&body).unwrap();
         assert_eq!(v["id"], 1);
         assert!(v["result"].is_array());
+    }
+
+    #[test]
+    fn make_notification_round_trip() {
+        let body = make_notification(
+            "textDocument/publishDiagnostics",
+            json!({"uri": "file://x.gdshader", "diagnostics": []}),
+        );
+        let v: Value = serde_json::from_slice(&body).unwrap();
+        assert_eq!(v["jsonrpc"], "2.0");
+        assert_eq!(v["method"], "textDocument/publishDiagnostics");
+        assert!(v.get("id").is_none());
     }
 
     #[test]

--- a/tests/integration.rs
+++ b/tests/integration.rs
@@ -119,7 +119,9 @@ async fn bridge_runs_against_live_godot() {
 
     // bridge::run reads from stdin; in the test runner stdin has no LSP payload so
     // read_message returns Ok(None) immediately → RunOutcome::StdinClosed.
-    let outcome = run(stream).await.expect("bridge::run returned an error");
+    let outcome = run(stream, std::time::Duration::from_secs(10))
+        .await
+        .expect("bridge::run returned an error");
     assert_eq!(
         outcome,
         RunOutcome::StdinClosed,

--- a/tests/integration.rs
+++ b/tests/integration.rs
@@ -119,7 +119,7 @@ async fn bridge_runs_against_live_godot() {
 
     // bridge::run reads from stdin; in the test runner stdin has no LSP payload so
     // read_message returns Ok(None) immediately → RunOutcome::StdinClosed.
-    let outcome = run(stream, std::time::Duration::from_secs(10))
+    let outcome = run(stream, std::time::Duration::from_secs(10), None)
         .await
         .expect("bridge::run returned an error");
     assert_eq!(


### PR DESCRIPTION
## Changes

- Add `src/shader.rs` module that validates `.gdshader` files by spawning
  Godot headless with an embedded GDScript, parsing stderr for compilation
  errors, and publishing `textDocument/publishDiagnostics` notifications
- Intercept `didOpen`, `didChange`, and `didClose` in the bridge for
  `.gdshader` URIs — trigger validation (debounced 300ms) on open/change,
  clear diagnostics on close
- Add `--godot-path` CLI flag and `config set godot-path` for explicit
  binary discovery (resolution: CLI → config → PATH → actionable diagnostic)
- Add `--shader-timeout` CLI option (default 10s) for the Godot subprocess
- Add `make_notification` helper to synthesizer for server-push messages
- When Godot binary is not found, publish a severity=3 hint diagnostic
  telling the user/AI to configure the path
- 18 new unit tests for stderr parsing, ANSI stripping, URI conversion,
  config keys, and CLI args

Closes #36

## References

[1]: https://github.com/GodOfAvacyn/gdshader-lsp
[2]: https://docs.godotengine.org/en/stable/tutorials/shaders/shader_reference/shader_preprocessor.html